### PR TITLE
添加 useTrack 支持

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,26 @@ fis.match('::package', {
 ```
 
 通过插件配置的规则优先于 `packTo`。
+
+## 关闭输出路径信息
+
+默认打包后输出路径信息,便于调试.形式如下
+
+```js
+/*!/components/underscore/underscore.js*/
+```
+
+可以在插件的配置中关闭路径信息输出
+
+```js
+fis.match('::package', {
+  packager: fis.plugin('map', {
+    useTrack : false, // 是否输出路径信息,默认为 true
+    'pkg/all.js': [
+       'libs/*.js',
+       'widget/*.js'
+    ]
+  })
+})
+```
+

--- a/index.js
+++ b/index.js
@@ -18,6 +18,14 @@ var _ = fis.util;
 module.exports = function(ret, pack, settings, opt) {
   var fromSettings = false;
 
+  // 是否添加调试信息
+  var useTrack = true;
+
+  if (_.has(settings,'useTrack')){
+    useTrack = settings.useTrack;
+    delete settings.useTrack;
+  }
+
   if (settings && Object.keys(settings).length) {
     fromSettings = true;
     pack = settings;
@@ -148,8 +156,12 @@ module.exports = function(ret, pack, settings, opt) {
           } else if (file.isCssLike) {
             c = c.replace(/@charset\s+(?:'[^']*'|"[^"]*"|\S*);?/gi, '');
           }
-
-          content += '/*!' + file.subpath + '*/\n' + c;
+          if(useTrack){
+            content += '/*!' + file.subpath + '*/\n' + c;
+          }
+          else{
+            content += c;
+          }
         }
 
         ret.map.res[id].pkg = pid;


### PR DESCRIPTION
`useTrack` 默认为 `true`, 如果设置为 `false`,则不再输出 track 信息。
已经在本地测试正常，请 @2betop 审核一下 ~~
